### PR TITLE
re-add jquery dep for the burger icon to work

### DIFF
--- a/www/monitor/index.html
+++ b/www/monitor/index.html
@@ -262,7 +262,7 @@
     </div>
   </footer>
 
-  <!--script src="/js/3rd-party/jquery-3.3.1.slim.min.js"></script-->
+  <script src="/js/3rd-party/jquery-3.3.1.slim.min.js"></script>
   <script src="/js/3rd-party/bootstrap.min.js"></script>
   <script src="/js/3rd-party/d3.v5.min.js"></script>
   <script src="/js/monitor/monitor-draw.js"></script>


### PR DESCRIPTION
Sadly the bootstrap navbar toggle on mobile requires jquery. As a
quick fix I'll add it back in.