### PR TITLE
fix: switch input and outputs in radius select

### DIFF
--- a/www/monitor/index.html
+++ b/www/monitor/index.html
@@ -156,8 +156,8 @@
               <select id="select-radius" class="custom-select" autocomplete="off">
                 <option value="0">Uniform</option>
                 <option value="1" selected>Size</option>
-                <option value="2">Inputs</option>
-                <option value="3">Outputs</option>
+                <option value="3">Inputs</option>
+                <option value="2">Outputs</option>
                 <option value="4">Inputs and Outputs</option>
                 <option value="5">Inputs per Outputs</option>
                 <option value="6">Outputs per Inputs</option>


### PR DESCRIPTION
The Inputs and Outputs value were switched in the Radius select.
This commit fixes this.