### PR TITLE
BitGo: Use 2 block target instead of 1 block target

### DIFF
--- a/memod/fetcher/feerate.go
+++ b/memod/fetcher/feerate.go
@@ -113,7 +113,7 @@ func getBitgoCom(cBitgoCom chan types.FeeAPIResponse3) {
 		cBitgoCom <- types.FeeAPIResponse3{0, 0, 0}
 		return
 	}
-	result := gjson.GetMany(string(body), "feeByBlockTarget.1", "feeByBlockTarget.3", "feeByBlockTarget.6")
+	result := gjson.GetMany(string(body), "feeByBlockTarget.2", "feeByBlockTarget.4", "feeByBlockTarget.6")
 	highFee, medFee, lowFee := result[0].Float()/1000, result[1].Float()/1000, result[2].Float()/1000
 
 	cBitgoCom <- types.FeeAPIResponse3{highFee, medFee, lowFee}

--- a/www/js/monitor/monitor-draw.js
+++ b/www/js/monitor/monitor-draw.js
@@ -456,7 +456,7 @@ async function drawFeerateAPILines(xMin){
   const descriptions = {
     0: "No feerate estimator overlayed.", // none
     1: "Feerates for a confirmation in half an hour, one hour and two hours are shown.", // bitcoinerlive
-    2: "Feerates for a confirmation in one, three and six blocks shown.", // bitgocom
+    2: "Feerates for a confirmation in two, four and six blocks shown.", // bitgocom
     3: "Feerates for a confirmation in two, three and six blocks shown.", // bitpaycom
     4: "Feerates for a priority and regular confirmation shown.", // blockchaininfo
     5: "The recommended feerate is shown. Feerate estimation data retrieved from <a href=\"https://blockchair.com/\">blockchair.com</a>.", // blockchaircom


### PR DESCRIPTION
The default BitGo block target is 2, the block target 1 is only provided on the overview but is disallowed in the transaction building call.

Hence, I suggest that the block targets for BitGo be updated to 2, 4, and 6. Those values should be more representative for actual use.