### PR TITLE
Add highlight and tooltip for tx version

### DIFF
--- a/www/js/monitor/monitor-draw.js
+++ b/www/js/monitor/monitor-draw.js
@@ -39,6 +39,8 @@ var cFeerate = function (d) {return feerateColorScale(yValue(d));}
 var cSegWit = function (d) {return d.spendsSegWit ? color1 : color2;}
 var cLocktime = function (d) {return d.locktime > 0 ?  (d.locktime >= 500000000? "green" : color1) : color2;}
 var cRBF = function (d) {return d.signalsRBF ? color1 : color2;}
+var cVersion1 = function (d) {return d.version == 1 ? color1 : color2}
+var cVersion2 = function (d) {return d.version == 2 ? color1 : color2}
 var cOpReturn = function (d) {return d.opreturnLength ? color1 : color2;}
 var cBIP69 = function (d) {return d.isBIP69 ? color1 : color2;}
 var cMultisig = function (d) {return d.spendsMultisig ? color1 : color2;}
@@ -365,6 +367,14 @@ async function redraw() {
           currentColorFunction = cMultisig;
           descriptionFilter.html("Transactions spending Multisig are highlighted.");
           break;
+        case "7": // version1
+          currentColorFunction = cVersion1;
+          descriptionFilter.html("Version 1 transactions are highlighted.");
+          break;
+        case "8": // version2
+          currentColorFunction = cVersion2;
+          descriptionFilter.html("Version 2 transactions are highlighted.");
+          break;
       }
       drawTransactions(data)
     }, 10);
@@ -555,6 +565,7 @@ function formatTooltip(d){
       ${formatTooltipTableRow("Feerate", yValue(d).toFixed(2) + " sat/vbyte")}
       ${formatTooltipTableRow("Size", d.size + " vbyte")}
       ${formatTooltipTableRow("Fee", d.fee + " sat")}
+      ${formatTooltipTableRow("Version", d.version)}
       ${formatTooltipTableRow("Inputs", formatTooltipDicts(d.spends))}
       ${formatTooltipTableRow("Outputs", formatTooltipDicts(d.paysTo))}
       ${formatTooltipTableRow("Output amount", d.outputValue / 100000000 + " BTC")}

--- a/www/monitor/index.html
+++ b/www/monitor/index.html
@@ -179,6 +179,8 @@
                 <option value="4">Highlight RBF signaling</option>
                 <option value="5">Highlight OP_RETURN</option>
                 <option value="6">Highlight BIP-69 compliant</option>
+                <option value="7">Highlight Version 1</option>
+                <option value="8">Highlight Version 2</option>
               </select>
               <p class="my-2 small font-weight-light" id="span-highlight-description">No transactions are highlighted.</p>
             </div>


### PR DESCRIPTION
A filter for transaction versions was added in #53 to the Bitcoin Transaction Monitor. This adds the option to highlight either v1 or v2 transactions. Additionally, the version is now displayed in the tool-tip on hovering over a dot.