### PR TITLE
Add block inclusion highlight

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,6 +46,7 @@ func main() {
 		api.GET("/transactionStats", getTransactionStats)
 		api.GET("/getMempoolEntries", getCachedMempoolEntries)
 		api.GET("/getRecentFeerateAPIData", getRecentFeerateAPIEntries)
+		api.GET("/getBlockEntries", getBlockEntries)
 	}
 
 	portString := ":" + config.GetString("api.port")
@@ -83,6 +84,19 @@ func getMempool(c *gin.Context) {
 func getRecentBlocks(c *gin.Context) {
 
 	blocks, err := database.GetRecentBlocks()
+	if err != nil {
+		fmt.Println(err.Error())
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Database error",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, blocks)
+}
+
+func getBlockEntries(c *gin.Context) {
+	blocks, err := database.GetBlockEntries()
 	if err != nil {
 		fmt.Println(err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -81,6 +81,7 @@ func GetMempool() (timestamp time.Time, feerateMapJSON string, megabyteMarkersJS
 	return
 }
 
+// GetRecentBlocks returns the 10 most recent blocks.
 func GetRecentBlocks() (blocks []types.RecentBlock, err error) {
 	c := Pool.Get()
 	defer c.Close()
@@ -94,6 +95,30 @@ func GetRecentBlocks() (blocks []types.RecentBlock, err error) {
 	for index := range reJSON {
 		block := types.RecentBlock{}
 		err = json.Unmarshal([]byte(reJSON[index]), &block)
+		if err != nil {
+			return
+		}
+		blocks = append(blocks, block)
+	}
+
+	return
+}
+
+
+// GetBlockEntries returns the 20 most recent blocks with short TXIDs.
+func GetBlockEntries() (blocks []types.BlockEntry, err error) {
+	c := Pool.Get()
+	defer c.Close()
+
+	beJSON, err := redis.Strings(c.Do("LRANGE", "blockEntries", 0, 20))
+	if err != nil {
+		return
+	}
+
+	blocks = make([]types.BlockEntry, 0)
+	for index := range beJSON {
+		block := types.BlockEntry{}
+		err = json.Unmarshal([]byte(beJSON[index]), &block)
 		if err != nil {
 			return
 		}

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -40,3 +40,12 @@ type MempoolEntry struct {
 	Spends         map[string]int `json:"spends"`
 	PaysTo         map[string]int `json:"paysTo"`
 }
+
+// BlockEntry holds the height, the first-seen timestamp and 
+// shortended TXIDs. It's used in the Bitcoin Transaction Monitor
+// to mark transactions by block they were included in.
+type BlockEntry struct {
+	Height     int      `json:"height"`
+	Timestamp  int64    `json:"timestamp"`
+	ShortTXIDs []string `json:"shortTXIDs"`
+}

--- a/memod/types/database.go
+++ b/memod/types/database.go
@@ -40,3 +40,12 @@ type MempoolEntry struct {
 	Spends         map[string]int `json:"spends"`
 	PaysTo         map[string]int `json:"paysTo"`
 }
+
+// BlockEntry holds the height, the first-seen timestamp and
+// shortended TXIDs. It's used in the Bitcoin Transaction Monitor
+// to mark transactions by block they were included in.
+type BlockEntry struct {
+	Height     int      `json:"height"`
+	Timestamp  int64    `json:"timestamp"`
+	ShortTXIDs []string `json:"shortTXIDs"`
+}

--- a/www/js/monitor/monitor.js
+++ b/www/js/monitor/monitor.js
@@ -31,6 +31,20 @@ async function loadRecentFeerateAPIData(){
   return gRecentFeerateAPIData
 }
 
+async function loadBlockEntriesData(){  
+  if ( gBlockEntriesData == null ) {
+    await d3.json(gApiHost + "/api/getBlockEntries").then(function (data) { 
+      for (const block of data) {
+        block.shortTXIDs.sort(function(a, b) {
+          return a > b;
+        });
+      }
+      gBlockEntriesData = data
+    });
+  }
+  return gBlockEntriesData
+}
+
 function scrollEventHandler() {
   // handle scroll offset over 60px from top to animate the mempool observer icon
   let navbar = document.getElementsByClassName("navbar")
@@ -148,6 +162,8 @@ window.onload = function () {
   readInitalQueryString()
   drawFilters()
   loadRecentFeerateAPIData() // preload current feerate API data
+  loadBlockEntriesData() // preload current block entries data
+
   redraw().then(function(){
     // Draw for the first time to initialize.
     disableEveryInput(false);

--- a/www/monitor/index.html
+++ b/www/monitor/index.html
@@ -181,6 +181,7 @@
                 <option value="6">Highlight BIP-69 compliant</option>
                 <option value="7">Highlight Version 1</option>
                 <option value="8">Highlight Version 2</option>
+                <option value="9">Highlight Block inclusion</option>
               </select>
               <p class="my-2 small font-weight-light" id="span-highlight-description">No transactions are highlighted.</p>
             </div>


### PR DESCRIPTION
This adds an option to highlight (colorize) transactions by the block they were included in to the Bitcoin Transaction Monitor.

This is done by writing the blocks and their timestamps to an extra Redis list. This list contains an array of shortened TXIDs (only the first 16 chars). 