### PR TITLE
fix: sorting of short txid strings

### DIFF
--- a/www/js/monitor/monitor.js
+++ b/www/js/monitor/monitor.js
@@ -35,9 +35,7 @@ async function loadBlockEntriesData(){
   if ( gBlockEntriesData == null ) {
     await d3.json(gApiHost + "/api/getBlockEntries").then(function (data) { 
       for (const block of data) {
-        block.shortTXIDs.sort(function(a, b) {
-          return a > b;
-        });
+        block.shortTXIDs.sort();        
       }
       gBlockEntriesData = data
     });


### PR DESCRIPTION
Browsers like for example Chrome did not sort the txids correctly.
The binary search failed. Now the default browser sorting is used.

Bug was introduced with https://github.com/0xB10C/memo/pull/56.