### PR TITLE
add: highlight for unconfirmed transactions

### DIFF
--- a/www/js/monitor/monitor-draw.js
+++ b/www/js/monitor/monitor-draw.js
@@ -80,6 +80,27 @@ var cBlockInclusion = function(d) {
   }
   return color2
  }
+ var cUnconfirmed = function(d) {
+  if (d.block != null) {
+    return color2
+  }
+
+  const shortTXID = d.txid.substring(0, 16)
+  for (const block of gBlockEntriesData) {
+
+    // skip if the block was found before the transaction was broadcast
+    if (block.timestamp < d.entryTime) {
+      continue
+    }
+
+    if (binarySearch(block.shortTXIDs, shortTXID) != -1) {
+      d.block = block.height
+      return color2
+    }
+
+  }
+  return color1
+ }
 
 // radius functions for the dots
 var rUniform = function (d) {return 2}
@@ -414,6 +435,10 @@ async function redraw() {
         case "9": // block inclusion
           currentColorFunction = cBlockInclusion;
           descriptionFilter.html("Transactions are highlighted according to the block they were include in.");
+          break;
+        case "10": // unconfirmed
+          currentColorFunction = cUnconfirmed;
+          descriptionFilter.html("Unconfirmed transactions are highlighted.");
           break;
       }
       drawTransactions(data)

--- a/www/monitor/index.html
+++ b/www/monitor/index.html
@@ -182,6 +182,7 @@
                 <option value="7">Highlight Version 1</option>
                 <option value="8">Highlight Version 2</option>
                 <option value="9">Highlight Block inclusion</option>
+                <option value="10">Highlight unconfirmed</option>
               </select>
               <p class="my-2 small font-weight-light" id="span-highlight-description">No transactions are highlighted.</p>
             </div>


### PR DESCRIPTION
This adds the option to highlight only unconfirmed transactions to the Bitcoin Transaction Monitor. 