### PR TITLE
fix: yMax == NaN

### DIFF
--- a/www/js/monitor/monitor-draw.js
+++ b/www/js/monitor/monitor-draw.js
@@ -153,14 +153,18 @@ async function redraw() {
   var tooltip = d3.select(gDivChart).append("div")
     .attr("class", "tooltip")
     .style("opacity", 0);
-  
+
   data = await loadEntryData()
   dataBlocks = await loadBlockEntriesData()
+
+  // The API can, in some cases, return JSON mempool entries where only the fee
+  // and entry-time are set. This is a bug. As workaround, filter these entries.
+  data = data.filter(d => d.txid != "");
 
   var xMin = d3.min(data, function (d) {return xValue(d)})
   var xMax = d3.max(data, function (d) {return xValue(d)})
 
-  // currently no used in favor of yMinQuantile and yMaxQuantile
+  // currently not used in favor of yMinQuantile and yMaxQuantile
   var yMin = d3.min(data, function (d) {return yValue(d)})
   var yMax = d3.max(data, function (d) {return yValue(d)})
 


### PR DESCRIPTION
Since the API sometimes returns JSON values with not all fields set (that's a bug which is being worked around here), it can happen that the size-field is 0. This results in a division-by-0 when calculating the feerate and the max value for the y-axis can't be calculated. No transactions are drawn. This is fixed here by filtering the JSON values where not all fields are set.

I didn't futher investigate why the API returns incorrect JSON values.