### PR TITLE
fix: getrawmempool fee decoding

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -8,13 +8,11 @@ import (
 	"github.com/0xb10c/memo/types"
 )
 
-/* decodes and encodes */
-
-// DecodeFetchedMempoolBody decode the Body of the JSON response as a map of PartialTransactions
-func DecodeFetchedMempoolBody(body []byte) (map[string]types.PartialTransaction, error) {
+// DecodeFetchedMempoolBody decode the Body of the JSON response as a map of PartialMempoolEntry
+func DecodeFetchedMempoolBody(body []byte) (map[string]types.PartialMempoolEntry, error) {
 	defer logger.TrackTime(time.Now(), "decodeFetchedMempoolBody()")
 
-	var mempool map[string]types.PartialTransaction
+	var mempool map[string]types.PartialMempoolEntry
 	err := json.Unmarshal(body, &mempool)
 	if err != nil {
 		return nil, err

--- a/types/mempool.go
+++ b/types/mempool.go
@@ -1,39 +1,15 @@
 package types
 
-/*
-type Fees struct {
-	Base       float64 `json:"base"`
-	Modified   float64 `json:"modified"`
-	Ancestor   float64 `json:"ancestor"`
-	Descendant float64 `json:"descendant"`
-}
-
-type Transaction struct {
-	Fees              Fees          `json:"fees"`
-	Size              int           `json:"size"`
-	Fee               float64       `json:"fee"`
-	Modifiedfee       float64       `json:"modifiedfee"`
-	Time              int           `json:"time"`
-	Height            int           `json:"height"`
-	Descendantcount   int           `json:"descendantcount"`
-	Descendantsize    int           `json:"descendantsize"`
-	Descendantfees    int           `json:"descendantfees"`
-	Ancestorcount     int           `json:"ancestorcount"`
-	Ancestorsize      int           `json:"ancestorsize"`
-	Ancestorfees      int           `json:"ancestorfees"`
-	Wtxid             string        `json:"wtxid"`
-	Depends           []interface{} `json:"depends"`
-	Spentby           []interface{} `json:"spentby"`
-	Bip125Replaceable bool          `json:"bip125-replaceable"`
-}
-*/
-
-// PartialTransaction is a part-struct of `Transaction` which contains
-// only the for-now-used values to be more memory efficient
-type PartialTransaction struct {
-	Size              int     `json:"vsize"`
-	Fee               float64 `json:"fee"`
-	Time              int     `json:"time"`
-	Wtxid             string  `json:"wtxid"`
-	Bip125Replaceable bool    `json:"bip125-replaceable"`
+// PartialMempoolEntry is slimmed down version of Bitcoin Core's mempool entry
+// returned by the getrawmempool RPC. This allows us to be more memory efficient.
+// See https://github.com/bitcoin/bitcoin/blob/6d5790956f45e3de5c6c4ee6fda21878b0d1287b/src/rpc/mempool.cpp#L253-L279
+type PartialMempoolEntry struct {
+	Size int     `json:"vsize"`
+	Fee  float64 `json:"fees.base"`
+	Fees struct {
+		Base float64 `json:"base"`
+	} `json:"fees"`
+	Time              int    `json:"time"`
+	Wtxid             string `json:"wtxid"`
+	Bip125Replaceable bool   `json:"bip125-replaceable"`
 }


### PR DESCRIPTION
In older versions of Bitcoin Core, each mempool entry had a field called `fee`. This is now called `fees.base`.